### PR TITLE
UX improvement: Avoid full page reload on nickname/color changes

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "js-cookie": "^3.0.5",
         "lucide-vue-next": "^0.349.0",
         "path": "^0.12.7",
+        "pinia": "^2.1.7",
         "radix-vue": "^1.5.0",
         "tailwind-merge": "^2.2.1",
         "tailwindcss-animate": "^1.0.7",
@@ -2077,6 +2078,56 @@
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinia": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.1.7.tgz",
+      "integrity": "sha512-+C2AHFtcFqjPih0zpYuvof37SFxMQ7OEG2zV9jRI12i9BOy3YQVAHwdKtyyc8pDcDyIc33WCIsZaCFWU7WWxGQ==",
+      "dependencies": {
+        "@vue/devtools-api": "^6.5.0",
+        "vue-demi": ">=0.14.5"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.4.0",
+        "typescript": ">=4.4.4",
+        "vue": "^2.6.14 || ^3.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pinia/node_modules/vue-demi": {
+      "version": "0.14.7",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.7.tgz",
+      "integrity": "sha512-EOG8KXDQNwkJILkx/gPcoL/7vH+hORoBaKgGe+6W7VFMvCYJfmF2dGbvgDroVnI8LU7/kTu8mbjRZGBU1z9NTA==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
       }
     },
     "node_modules/pirates": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
     "js-cookie": "^3.0.5",
     "lucide-vue-next": "^0.349.0",
     "path": "^0.12.7",
+    "pinia": "^2.1.7",
     "radix-vue": "^1.5.0",
     "tailwind-merge": "^2.2.1",
     "tailwindcss-animate": "^1.0.7",

--- a/frontend/src/components/DataTableColumn.vue
+++ b/frontend/src/components/DataTableColumn.vue
@@ -103,7 +103,7 @@ const submitNickname = async () => {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
   
-    toast(`Updated nickname to ${nickname.value}`, {
+    toast(nickname.value === "" ? 'Removed nickname' : `Updated nickname to ${nickname.value}`, {
       description: "",
     });
 

--- a/frontend/src/components/DataTableColumn.vue
+++ b/frontend/src/components/DataTableColumn.vue
@@ -18,6 +18,9 @@ import { ref, defineEmits } from 'vue';
 import Cookies from 'js-cookie'
 import { isUserLoggedIn } from '@/lib/utils'
 import { useRouter } from 'vue-router'
+import { useDeviceStore } from '@/lib/store'
+
+const deviceStore = useDeviceStore();
 
 const props = defineProps<{
   device: Device
@@ -78,6 +81,10 @@ const saveChanges = async () => {
 let nickname = ref(props.device.nickname);
 
 const submitNickname = async () => {
+  // Update the nickname locally
+  deviceStore.setNickname(props.device.device_id, nickname.value);
+
+  // Update the nickname on the backend
   if (isUserLoggedIn()) {
     const token = Cookies.get('token');
     const response = await fetch(`${import.meta.env.VITE_BACKEND_URL}/change-nickname`, {
@@ -96,14 +103,12 @@ const submitNickname = async () => {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
   
-    // Clear the input field
-    nickname.value = '';
-  
-    location.reload();
-  
-    toast('Updated nickname', {
+    toast(`Updated nickname to ${nickname.value}`, {
       description: "",
     });
+
+    // Clear the input field
+    nickname.value = '';
   } else {
     toast('Your preference will not be saved.', {
       description: 'You must be logged in to save your preferences.',

--- a/frontend/src/components/DataTableColumn.vue
+++ b/frontend/src/components/DataTableColumn.vue
@@ -44,6 +44,8 @@ const router = useRouter();
 
 
 const saveChanges = async () => {
+  deviceStore.setColor(props.device, selectedColor.value);
+
   if (isUserLoggedIn()) {
     const token = Cookies.get('token');
     const response = await fetch(`${import.meta.env.VITE_BACKEND_URL}/change-color`, {
@@ -61,8 +63,6 @@ const saveChanges = async () => {
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
-  
-    location.reload();
   
     toast('Updated color', {
       description: "",

--- a/frontend/src/components/GoogleMapLoader.vue
+++ b/frontend/src/components/GoogleMapLoader.vue
@@ -3,26 +3,23 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, defineProps, watch } from 'vue'
+import { onMounted, watch } from 'vue'
 import { Loader } from '@googlemaps/js-api-loader'
 import { Device } from '@/lib/types'
 import { isUserLoggedIn } from '@/lib/utils';
-// import { renderToString } from '@vue/server-renderer'
-// import DeviceMarker from '@/components/DeviceMarker.vue'
 import Cookies from 'js-cookie';
+import { useDeviceStore } from '@/lib/store';
+
+const deviceStore = useDeviceStore();
 
 let map: google.maps.Map | null = null;
 let markers: { [device_id: string]: google.maps.marker.AdvancedMarkerElement } = {};
-const props = defineProps<{
-  selectedDevice: Device | null,
-  devices: Device[],
-}>();
 
 const emit = defineEmits(['update:selectedDevice']);
 const selectDevice = (device: Device | null) => {
     emit('update:selectedDevice', device);
 };
-watch(() => props.selectedDevice, (newDevice, _) => {
+watch(() => deviceStore.selectedDevice, (newDevice, _) => {
   if (newDevice && newDevice.latitude && newDevice.longitude) {
     map?.panTo({ lat: newDevice.latitude, lng: newDevice.longitude });
   }
@@ -37,7 +34,7 @@ const loader = new Loader({
 const updateDevices = async () => {
   if (document.getElementById('map')) {
     loader.load().then(async () => {
-      for (const device of props.devices) {
+      for (const device of deviceStore.devices) {
         if (markers[device.device_id]) {
           if (device.is_hidden) {
             markers[device.device_id].map = null;
@@ -68,7 +65,7 @@ const updateDevices = async () => {
     }
   };
 
-watch(() => props.devices, async () => {
+watch(() => deviceStore.devices, async () => {
   await updateDevices();
 }, { immediate: true, deep: true });
   

--- a/frontend/src/components/GoogleMapLoader.vue
+++ b/frontend/src/components/GoogleMapLoader.vue
@@ -15,9 +15,10 @@ const deviceStore = useDeviceStore();
 let map: google.maps.Map | null = null;
 let markers: { [device_id: string]: google.maps.marker.AdvancedMarkerElement } = {};
 
-const emit = defineEmits(['update:selectedDevice']);
 const selectDevice = (device: Device | null) => {
-    emit('update:selectedDevice', device);
+  if (device) {
+    deviceStore.setSelectedDevice(device);
+  }
 };
 watch(() => deviceStore.selectedDevice, (newDevice, _) => {
   if (newDevice && newDevice.latitude && newDevice.longitude) {
@@ -39,25 +40,31 @@ const updateDevices = async () => {
           if (device.is_hidden) {
             markers[device.device_id].map = null;
           } else {
-            markers[device.device_id].map = map;
             // Remove the existing marker
-            // markers[device.device_id].map = null;
+            markers[device.device_id].map = null;
 
-            // // Create a new marker with the updated color
-            // const markerElement = document.createElement('div');
-            // markerElement.style.width = '30px';
-            // markerElement.style.height = '30px';
-            // markerElement.style.cursor = 'pointer';
-            // markerElement.innerHTML = `
-            //   <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="${device.color}" style="transform: rotate(${device.angle}deg);">
-            //     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
-            //     </svg>
-            // `;
-            // markers[device.device_id] = new google.maps.marker.AdvancedMarkerElement({
-            //   position: { lat: device.latitude, lng: device.longitude },
-            //   map: map,
-            //   content: markerElement,
-            // });
+            // Create a new marker with the updated color
+            const markerElement = document.createElement('div');
+            markerElement.style.width = '30px';
+            markerElement.style.height = '30px';
+            markerElement.style.cursor = 'pointer';
+            markerElement.innerHTML = `
+              <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="${device.color}" style="transform: rotate(${device.angle}deg);">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
+                </svg>
+            `;
+            const marker = new google.maps.marker.AdvancedMarkerElement({
+              position: { lat: device.latitude, lng: device.longitude },
+              map: map,
+              content: markerElement,
+            });
+
+            marker.addListener("click", () => {
+              map?.panTo({ lat: device.latitude, lng: device.longitude });
+              selectDevice(device);
+            });
+
+            markers[device.device_id] = marker;
           }
         }
       }

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -1,20 +1,12 @@
 <script setup lang="ts">
-import { defineProps, defineEmits, inject, Ref } from 'vue'
 import { cn, isUserLoggedIn } from '@/lib/utils'
 import { Button } from '@/components/ui/button'
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar'
 import Logo from '@/components/Logo.vue'
-import { Device } from '@/lib/types'
 import DeviceTable from '@/components/DeviceTable.vue'
+import { useUserStore } from '@/lib/store'
 
-defineProps<{
-  selectedDevice: Device | null,
-  devices: Device[],
-}>();
-
-const emit = defineEmits(['update:selectedDevice', 'update:devices']);
-
-const username = inject('username') as Ref<string | null>;
+const userStore = useUserStore();
 </script>
 
 <template>
@@ -72,19 +64,14 @@ const username = inject('username') as Ref<string | null>;
             Devices
         </h2>
         <div class="py-2 overflow-auto">
-            <DeviceTable
-                :devices="devices"
-                :selectedDevice="selectedDevice"
-                @update:selectedDevice="selectedDevice => emit('update:selectedDevice', selectedDevice)"
-                @update:devices="devices => emit('update:devices', devices)"
-            />
+            <DeviceTable />
         </div>
         <div class="absolute bottom-4 left-4 flex items-center gap-2">
             <Avatar class="flex items-center cursor-pointer" v-if="isUserLoggedIn()">
-                <AvatarImage :src="`https://avatars.jakerunzer.com/${username}.png`" alt="@radix-vue" />
-                <AvatarFallback>{{username ? username[0] : ''}}</AvatarFallback>
+                <AvatarImage :src="`https://avatars.jakerunzer.com/${userStore.username}.png`" alt="@radix-vue" />
+                <AvatarFallback>{{userStore.username ? userStore.username[0] : ''}}</AvatarFallback>
             </Avatar>
-            <div class="font-bold cursor-pointer">{{username}}</div>
+            <div class="font-bold cursor-pointer">{{userStore.username}}</div>
         </div>
     </div>
   </div>

--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -32,10 +32,10 @@ export const useDeviceStore = defineStore({
                 device.nickname = nickname;
             }
         },
-        setColor(deviceId: string, color: string) {
-            const device = this.devices.find(device => device.device_id === deviceId);
-            if (device) {
-                device.color = color;
+        setColor(device: Device, color: string) {
+            const targetDevice = this.devices.find(d => d.device_id === device.device_id);
+            if (targetDevice) {
+                targetDevice.color = color;
             }
         },
         setHidden(device: Device, hidden: boolean) {

--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -1,0 +1,21 @@
+import { defineStore } from 'pinia';
+import { Device } from '@/lib/types'
+
+export const useDeviceStore = defineStore({
+    id: 'devices',
+    state: () => ({
+        devices: [] as Device[],
+    }),
+    actions: {
+        setDevices(updatedDevices: Device[]) {
+            this.devices = updatedDevices;
+        },
+        setNickname(deviceId: string, nickname: string) {
+            const device = this.devices.find(device => device.device_id === deviceId);
+            if (device) {
+                device.nickname = nickname;
+            }
+            console.log(nickname);
+        }
+    }
+});

--- a/frontend/src/lib/store.ts
+++ b/frontend/src/lib/store.ts
@@ -1,12 +1,28 @@
 import { defineStore } from 'pinia';
 import { Device } from '@/lib/types'
 
+export const useUserStore = defineStore({
+    id: 'user',
+    state: () => ({
+        username: '',
+    }),
+    actions: {
+        setUsername(username: string) {
+            this.username = username;
+        },
+    },
+});
+
 export const useDeviceStore = defineStore({
     id: 'devices',
     state: () => ({
         devices: [] as Device[],
+        selectedDevice: null as Device | null,
     }),
     actions: {
+        setSelectedDevice(device: Device) {
+            this.selectedDevice = device;
+        },
         setDevices(updatedDevices: Device[]) {
             this.devices = updatedDevices;
         },
@@ -15,7 +31,19 @@ export const useDeviceStore = defineStore({
             if (device) {
                 device.nickname = nickname;
             }
-            console.log(nickname);
+        },
+        setColor(deviceId: string, color: string) {
+            const device = this.devices.find(device => device.device_id === deviceId);
+            if (device) {
+                device.color = color;
+            }
+        },
+        setHidden(device: Device, hidden: boolean) {
+            const deviceId = device.device_id
+            const targetDevice = this.devices.find(device => device.device_id === deviceId);
+            if (targetDevice) {
+                targetDevice.is_hidden = hidden;
+            }
         }
     }
 });

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -13,8 +13,11 @@ import GoogleMapLoader from '@/components/GoogleMapLoader.vue'
 import AuthView from '@/views/AuthView.vue'
 
 import { isUserLoggedIn } from '@/lib/utils'
+import { createPinia } from 'pinia'
 
 const app = createApp(App);
+const pinia = createPinia();
+app.use(pinia);
 
 const router = createRouter({
     history: createWebHistory(),

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -4,6 +4,9 @@ import Sidebar from '@/components/Sidebar.vue'
 import { Device } from '@/lib/types'
 import { isUserLoggedIn } from '@/lib/utils'
 import Cookies from 'js-cookie'
+import { useDeviceStore } from '@/lib/store'
+
+const deviceStore = useDeviceStore();
 
 const selectedDevice = ref<Device | null>(null);
 const devices = ref<Device[]>([]);
@@ -20,7 +23,10 @@ const fetchDevices = async () => {
                 Authorization: `Bearer ${token}`,
             },
         });
-        devices.value = await response.json();
+        const json = await response.json();
+        devices.value = json;
+        deviceStore.setDevices(json);
+
     } else {
         const response = await fetch(`${import.meta.env.VITE_BACKEND_URL}/device-locations`);
         devices.value = await response.json();
@@ -53,7 +59,6 @@ onUnmounted(() => {
 </script>
 
 <template>
-    <!-- <Navbar variant="dashboard" /> -->
     <div class="">
         <div class="bg-background">
             <div class="grid lg:grid-cols-5">

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -1,15 +1,11 @@
 <script setup lang="ts">
-import { onMounted, onUnmounted, ref } from 'vue';
+import { onMounted, onUnmounted } from 'vue';
 import Sidebar from '@/components/Sidebar.vue'
-import { Device } from '@/lib/types'
 import { isUserLoggedIn } from '@/lib/utils'
 import Cookies from 'js-cookie'
 import { useDeviceStore } from '@/lib/store'
 
 const deviceStore = useDeviceStore();
-
-const selectedDevice = ref<Device | null>(null);
-const devices = ref<Device[]>([]);
 
 let intervalId: number | null = null;
 const pollingRateSeconds = 30;
@@ -24,12 +20,12 @@ const fetchDevices = async () => {
             },
         });
         const json = await response.json();
-        devices.value = json;
         deviceStore.setDevices(json);
 
     } else {
         const response = await fetch(`${import.meta.env.VITE_BACKEND_URL}/device-locations`);
-        devices.value = await response.json();
+        const json = await response.json();
+        deviceStore.setDevices(json);
     }
 };
 
@@ -62,20 +58,8 @@ onUnmounted(() => {
     <div class="">
         <div class="bg-background">
             <div class="grid lg:grid-cols-5">
-                <Sidebar
-                    :selectedDevice="selectedDevice"
-                    :devices="devices"
-                    @update:selectedDevice="selectedDevice = $event"
-                    @update:devices="devices = $event"
-                    class="sidebar lg:block h-[100vh]"
-                />
-                <router-view
-                    :selectedDevice="selectedDevice"
-                    :devices="devices"
-                    @update:selectedDevice="selectedDevice = $event"
-                    @update:devices="devices = $event"
-                    class="col-span-3 lg:col-span-4 lg:border-l"
-                />
+                <Sidebar class="sidebar lg:block h-[100vh]" />
+                <router-view class="col-span-3 lg:col-span-4 lg:border-l" />
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Description

Currently, when a user saves changes to a device's nickname or color, the entire page reloads to apply these updates. This can lead to an awkward user experience, especially if the user has made multiple changes or is working with a large number of devices.

## Proposed Solution

To improve the user experience, we propose updating the application to make the update request to the backend and then apply the changes to the local data in the UI, without needing a full page reload or even a full reload of all the device data.

This change would make the application feel more responsive and would allow users to make multiple changes more efficiently.

This will be implemented by migrating device state logic to a Pinia store to streamline the state management process.